### PR TITLE
fix potential memory leak

### DIFF
--- a/src/ngx_http_encrypted_session_cipher.c
+++ b/src/ngx_http_encrypted_session_cipher.c
@@ -98,13 +98,14 @@ ngx_http_encrypted_session_aes_mac_encrypt(ngx_pool_t *pool, ngx_log_t *log,
     p += len;
 
     ret = EVP_EncryptFinal(&ctx, p, &len);
-    if (!ret) {
-        return NGX_ERROR;
-    }
 
     /* XXX we should still explicitly release the ctx
      * or we'll leak memory here */
     EVP_CIPHER_CTX_cleanup(&ctx);
+
+    if (!ret) {
+        return NGX_ERROR;
+    }
 
     p += len;
 


### PR DESCRIPTION
The alternative is:
```
    if (!ret) {		
        goto evp_error;
    }
```