### PR TITLE
feature: supported OpenSSL 1.1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,10 +24,6 @@ env:
     - PCRE_PREFIX=/opt/pcre
     - PCRE_LIB=$PCRE_PREFIX/lib
     - PCRE_INC=$PCRE_PREFIX/include
-    - DRIZZLE_VER=2011.07.21
-    - LIBDRIZZLE_PREFIX=/opt/drizzle
-    - LIBDRIZZLE_INC=$LIBDRIZZLE_PREFIX/include/libdrizzle-1.0
-    - LIBDRIZZLE_LIB=$LIBDRIZZLE_PREFIX/lib
     - JOBS=3
     - NGX_BUILD_JOBS=$JOBS
   matrix:
@@ -38,7 +34,6 @@ before_install:
   - sudo apt-get install -qq -y axel cpanminus libtest-base-perl libtext-diff-perl liburi-perl libwww-perl libtest-longstring-perl liblist-moreutils-perl > build.log 2>&1 || (cat build.log && exit 1)
 
 install:
-  - if [ ! -f download-cache/drizzle7-$DRIZZLE_VER.tar.gz ]; then wget -P download-cache http://openresty.org/download/drizzle7-$DRIZZLE_VER.tar.gz; fi
   - if [ ! -f download-cache/pcre-$PCRE_VER.tar.gz ]; then wget -P download-cache http://ftp.cs.stanford.edu/pub/exim/pcre/pcre-$PCRE_VER.tar.gz; fi
   - if [ ! -f download-cache/openssl-$OPENSSL_VER.tar.gz ]; then wget -P download-cache https://www.openssl.org/source/openssl-$OPENSSL_VER.tar.gz; fi
   - git clone https://github.com/openresty/nginx-devel-utils.git
@@ -55,11 +50,6 @@ script:
   - cd luajit2
   - make -j$JOBS CCDEBUG=-g Q= PREFIX=$LUAJIT_PREFIX CC=$CC XCFLAGS='-DLUA_USE_APICHECK -DLUA_USE_ASSERT' > build.log 2>&1 || (cat build.log && exit 1)
   - sudo make install PREFIX=$LUAJIT_PREFIX > build.log 2>&1 || (cat build.log && exit 1)
-  - cd ..
-  - tar xzf download-cache/drizzle7-$DRIZZLE_VER.tar.gz && cd drizzle7-$DRIZZLE_VER
-  - ./configure --prefix=$LIBDRIZZLE_PREFIX --without-server > build.log 2>&1 || (cat build.log && exit 1)
-  - make libdrizzle-1.0 -j$JOBS > build.log 2>&1 || (cat build.log && exit 1)
-  - sudo make install-libdrizzle-1.0 > build.log 2>&1 || (cat build.log && exit 1)
   - cd ..
   - tar zxf download-cache/pcre-$PCRE_VER.tar.gz
   - cd pcre-$PCRE_VER/

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,22 +17,27 @@ env:
     - LUAJIT_INC=$LUAJIT_PREFIX/include/luajit-2.1
     - LUA_INCLUDE_DIR=$LUAJIT_INC
     - LUA_CMODULE_DIR=/lib
+    - OPENSSL_PREFIX=/opt/ssl
+    - OPENSSL_LIB=$OPENSSL_PREFIX/lib
+    - OPENSSL_INC=$OPENSSL_PREFIX/include
     - JOBS=3
     - NGX_BUILD_JOBS=$JOBS
   matrix:
-    - NGINX_VERSION=1.9.15
+    - NGINX_VERSION=1.13.6 OPENSSL_VER=1.0.2k
+    - NGINX_VERSION=1.13.6 OPENSSL_VER=1.1.0c
 
 before_install:
   - sudo apt-get install -qq -y axel cpanminus libtest-base-perl libtext-diff-perl liburi-perl libwww-perl libtest-longstring-perl liblist-moreutils-perl > build.log 2>&1 || (cat build.log && exit 1)
 
 install:
+  - if [ ! -f download-cache/openssl-$OPENSSL_VER.tar.gz ]; then wget -P download-cache https://www.openssl.org/source/openssl-$OPENSSL_VER.tar.gz; fi
   - git clone https://github.com/openresty/nginx-devel-utils.git
   - git clone https://github.com/openresty/openresty.git ../openresty
   - git clone https://github.com/openresty/no-pool-nginx.git ../no-pool-nginx
   - git clone https://github.com/simpl/ngx_devel_kit.git ../ndk-nginx-module
   - git clone https://github.com/openresty/test-nginx.git
   - git clone -b v2.1-agentzh https://github.com/openresty/luajit2.git
-  - git clone https://github.com/openresty/lua-nginx-module.git ../lua-nginx-module
+  - git clone -b os11 https://github.com/spacewander/lua-nginx-module.git ../lua-nginx-module
   - git clone https://github.com/openresty/echo-nginx-module.git ../echo-nginx-module
   - git clone https://github.com/openresty/set-misc-nginx-module.git ../set-misc-nginx-module
 
@@ -40,6 +45,12 @@ script:
   - cd luajit2
   - make -j$JOBS CCDEBUG=-g Q= PREFIX=$LUAJIT_PREFIX CC=$CC XCFLAGS='-DLUA_USE_APICHECK -DLUA_USE_ASSERT' > build.log 2>&1 || (cat build.log && exit 1)
   - sudo make install PREFIX=$LUAJIT_PREFIX > build.log 2>&1 || (cat build.log && exit 1)
+  - cd ..
+  - tar zxf download-cache/openssl-$OPENSSL_VER.tar.gz
+  - cd openssl-$OPENSSL_VER/
+  - ./config shared --prefix=$OPENSSL_PREFIX -DPURIFY > build.log 2>&1 || (cat build.log && exit 1)
+  - make -j$JOBS > build.log 2>&1 || (cat build.log && exit 1)
+  - sudo make PATH=$PATH install_sw > build.log 2>&1 || (cat build.log && exit 1)
   - cd ..
   - cd test-nginx && sudo cpanm . && cd ..
   - export PATH=$PWD/work/nginx/sbin:$PWD/nginx-devel-utils:$PATH

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,14 @@ env:
     - OPENSSL_PREFIX=/opt/ssl
     - OPENSSL_LIB=$OPENSSL_PREFIX/lib
     - OPENSSL_INC=$OPENSSL_PREFIX/include
+    - PCRE_VER=8.40
+    - PCRE_PREFIX=/opt/pcre
+    - PCRE_LIB=$PCRE_PREFIX/lib
+    - PCRE_INC=$PCRE_PREFIX/include
+    - DRIZZLE_VER=2011.07.21
+    - LIBDRIZZLE_PREFIX=/opt/drizzle
+    - LIBDRIZZLE_INC=$LIBDRIZZLE_PREFIX/include/libdrizzle-1.0
+    - LIBDRIZZLE_LIB=$LIBDRIZZLE_PREFIX/lib
     - JOBS=3
     - NGX_BUILD_JOBS=$JOBS
   matrix:
@@ -30,6 +38,8 @@ before_install:
   - sudo apt-get install -qq -y axel cpanminus libtest-base-perl libtext-diff-perl liburi-perl libwww-perl libtest-longstring-perl liblist-moreutils-perl > build.log 2>&1 || (cat build.log && exit 1)
 
 install:
+  - if [ ! -f download-cache/drizzle7-$DRIZZLE_VER.tar.gz ]; then wget -P download-cache http://openresty.org/download/drizzle7-$DRIZZLE_VER.tar.gz; fi
+  - if [ ! -f download-cache/pcre-$PCRE_VER.tar.gz ]; then wget -P download-cache http://ftp.cs.stanford.edu/pub/exim/pcre/pcre-$PCRE_VER.tar.gz; fi
   - if [ ! -f download-cache/openssl-$OPENSSL_VER.tar.gz ]; then wget -P download-cache https://www.openssl.org/source/openssl-$OPENSSL_VER.tar.gz; fi
   - git clone https://github.com/openresty/nginx-devel-utils.git
   - git clone https://github.com/openresty/openresty.git ../openresty
@@ -45,6 +55,17 @@ script:
   - cd luajit2
   - make -j$JOBS CCDEBUG=-g Q= PREFIX=$LUAJIT_PREFIX CC=$CC XCFLAGS='-DLUA_USE_APICHECK -DLUA_USE_ASSERT' > build.log 2>&1 || (cat build.log && exit 1)
   - sudo make install PREFIX=$LUAJIT_PREFIX > build.log 2>&1 || (cat build.log && exit 1)
+  - cd ..
+  - tar xzf download-cache/drizzle7-$DRIZZLE_VER.tar.gz && cd drizzle7-$DRIZZLE_VER
+  - ./configure --prefix=$LIBDRIZZLE_PREFIX --without-server > build.log 2>&1 || (cat build.log && exit 1)
+  - make libdrizzle-1.0 -j$JOBS > build.log 2>&1 || (cat build.log && exit 1)
+  - sudo make install-libdrizzle-1.0 > build.log 2>&1 || (cat build.log && exit 1)
+  - cd ..
+  - tar zxf download-cache/pcre-$PCRE_VER.tar.gz
+  - cd pcre-$PCRE_VER/
+  - ./configure --prefix=$PCRE_PREFIX --enable-jit --enable-utf --enable-unicode-properties > build.log 2>&1 || (cat build.log && exit 1)
+  - make -j$JOBS > build.log 2>&1 || (cat build.log && exit 1)
+  - sudo PATH=$PATH make install > build.log 2>&1 || (cat build.log && exit 1)
   - cd ..
   - tar zxf download-cache/openssl-$OPENSSL_VER.tar.gz
   - cd openssl-$OPENSSL_VER/

--- a/src/ngx_http_encrypted_session_cipher.h
+++ b/src/ngx_http_encrypted_session_cipher.h
@@ -7,18 +7,29 @@
 #include <openssl/evp.h>
 
 
+typedef int (*cipher_ctx_reset_handle) (EVP_CIPHER_CTX *ctx);
+
+
+typedef struct {
+    EVP_CIPHER_CTX                     *session_ctx;
+    cipher_ctx_reset_handle             reset_cipher_ctx;
+} ngx_http_encrypted_session_main_conf_t;
+
+
 enum {
     ngx_http_encrypted_session_key_length = 256 / 8,
     ngx_http_encrypted_session_iv_length = EVP_MAX_IV_LENGTH
 };
 
 
-ngx_int_t ngx_http_encrypted_session_aes_mac_encrypt(ngx_pool_t *pool,
+ngx_int_t ngx_http_encrypted_session_aes_mac_encrypt(
+        ngx_http_encrypted_session_main_conf_t *esmcf, ngx_pool_t *pool,
         ngx_log_t *log, const u_char *iv, size_t iv_len, const u_char *key,
         size_t key_len, const u_char *in, size_t in_len,
         ngx_uint_t expires, u_char **dst, size_t *dst_len);
 
-ngx_int_t ngx_http_encrypted_session_aes_mac_decrypt(ngx_pool_t *pool,
+ngx_int_t ngx_http_encrypted_session_aes_mac_decrypt(
+        ngx_http_encrypted_session_main_conf_t *esmcf, ngx_pool_t *pool,
         ngx_log_t *log, const u_char *iv, size_t iv_len, const u_char *key,
         size_t key_len, const u_char *in, size_t in_len, u_char **dst,
         size_t *dst_len);

--- a/src/ngx_http_encrypted_session_cipher.h
+++ b/src/ngx_http_encrypted_session_cipher.h
@@ -23,13 +23,13 @@ enum {
 
 
 ngx_int_t ngx_http_encrypted_session_aes_mac_encrypt(
-        ngx_http_encrypted_session_main_conf_t *esmcf, ngx_pool_t *pool,
+        ngx_http_encrypted_session_main_conf_t *emcf, ngx_pool_t *pool,
         ngx_log_t *log, const u_char *iv, size_t iv_len, const u_char *key,
         size_t key_len, const u_char *in, size_t in_len,
         ngx_uint_t expires, u_char **dst, size_t *dst_len);
 
 ngx_int_t ngx_http_encrypted_session_aes_mac_decrypt(
-        ngx_http_encrypted_session_main_conf_t *esmcf, ngx_pool_t *pool,
+        ngx_http_encrypted_session_main_conf_t *emcf, ngx_pool_t *pool,
         ngx_log_t *log, const u_char *iv, size_t iv_len, const u_char *key,
         size_t key_len, const u_char *in, size_t in_len, u_char **dst,
         size_t *dst_len);

--- a/util/build.sh
+++ b/util/build.sh
@@ -11,8 +11,8 @@ force=$2
 
 ngx-build $force $version \
             --with-http_ssl_module \
-            --with-cc-opt="-I$OPENSSL_INC -I$PCRE_INC" \
-            --with-ld-opt="-L$OPENSSL_LIB -L$PCRE_LIB -Wl,-rpath,$OPENSSL_LIB:$PCRE_LIB:$LIBDRIZZLE_LIB" \
+            --with-cc-opt="-I$OPENSSL_INC" \
+            --with-ld-opt="-L$OPENSSL_LIB -Wl,-rpath,$OPENSSL_LIB" \
             --without-mail_pop3_module \
             --without-mail_imap_module \
             --without-mail_smtp_module \

--- a/util/build.sh
+++ b/util/build.sh
@@ -11,8 +11,8 @@ force=$2
 
 ngx-build $force $version \
             --with-http_ssl_module \
-            --with-cc-opt="-I$OPENSSL_INC" \
-            --with-ld-opt="-L$OPENSSL_LIB -Wl,-rpath,$OPENSSL_LIB" \
+            --with-cc-opt="-I$OPENSSL_INC -I$PCRE_INC" \
+            --with-ld-opt="-L$OPENSSL_LIB -L$PCRE_LIB -Wl,-rpath,$OPENSSL_LIB:$PCRE_LIB:$LIBDRIZZLE_LIB" \
             --without-mail_pop3_module \
             --without-mail_imap_module \
             --without-mail_smtp_module \


### PR DESCRIPTION
`EVP_CIPHER_CTX` is opaque after OpenSSL 1.1.0.
Replace `EVP_CIPHER_CTX_init` and `EVP_CIPHER_CTX_cleanup` with
`EVP_CIPHER_CTX_new` and `EVP_CIPHER_CTX_free`.