### PR TITLE
explicit specification of encryption in each request

### DIFF
--- a/t/sanity.t
+++ b/t/sanity.t
@@ -316,3 +316,30 @@ X-Foo: [a-z0-9=]+$
 --- error_log
 encrypted_session: expires=1382400
 
+
+
+=== TEST 12: explicit key with default iv
+--- config
+    encrypted_session_expires 0;
+
+    location /encode {
+        set $a 'abc';
+
+		set $session_key "abcdefghijklmnopqrstuvwxyz123456";
+        set_encrypt_session_keyed $res $a $session_key;
+
+        set_encode_base32 $ppres $res;
+
+        echo "res = $ppres";
+
+        set_decrypt_session $b $res;
+        echo "b = $b";
+    }
+--- request
+    GET /encode
+--- response_body
+res = ktrp3n437q42laejppc9d4bg0jpv0ejie106ooo65od9lf5huhs0====
+b = abc
+--- error_log
+encrypted_session: expires=0
+


### PR DESCRIPTION
I need to make two separate session encryptions within the same location and they shouldn't share the same key.  I tried in vain to add encryption key as an optional additional parameter to **set_encrypt_session** or **set_decrypt_session** but got stuck when I couldn't tell whether the optional parameter was specified.

As an alternative I added two new directives:
**set_encrypt_session_keyed** _`$target <value> <key>`_
**set_decrypt_session_keyed** _`$target <value> <key>`_